### PR TITLE
script and playbook added to check the sssd_conf status

### DIFF
--- a/sssd_check/ansible/sssd_check.yaml
+++ b/sssd_check/ansible/sssd_check.yaml
@@ -1,0 +1,19 @@
+---
+- name: check sssd
+  hosts: all
+  gather_facts: no
+  vars:
+    myfile: "/etc/sssd/sssd.conf"
+    myline: 'ldap_uri=ldap://ldapcorp'
+  become: true
+  tasks:
+    - name: line found
+      ansible.builtin.lineinfile:
+        name: "{{ myfile }}"
+        line: "{{ myline }}"
+        state: present
+      check_mode: true
+      register: conf
+      failed_when: (conf is changed ) or ( conf is failed)
+
+

--- a/sssd_check/sssd_check.sh
+++ b/sssd_check/sssd_check.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+ACCOUNTID=$1
+
+pushd ansible
+export ANSIBLE_HOST_KEY_CHECKING=False
+INVENTORY=$(jarvis ec2 find -st running -a $ACCOUNTID --ansible)
+ansible-playbook -i $INVENTORY sssd_check.yaml -u ****  --ask-pass  -K
+popd


### PR DESCRIPTION
This is about finding the instances from an aws account where latest ldap config has not been set. This ansible playbook only a read only one as I set **check_mode** to true. 

I have tested this with boxy charm-staging and bfs-staging aws account. 

